### PR TITLE
support for encoding blessed structures (default off)

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -43,6 +43,28 @@ sub _replace {
     return join "~", @parts;
 }
 
+subtest "blessed objects" => sub {
+
+    package MyMock;
+        sub new { bless { somekey => 'someval' }, shift }
+    package main;
+
+    my $data = {
+        foo  => 0,
+        mock => MyMock->new,
+    };
+
+    my $store = _gen_store(
+        {
+            allow_blessed => 1,
+        }
+    );
+
+    my $encoded = $store->encode($data);
+    my $decoded = $store->decode($encoded);
+    cmp_deeply( $decoded, $data, "routrip with object" );
+};
+
 subtest "defaults" => sub {
     my $store = _gen_store;
 


### PR DESCRIPTION
Hi David! Me again :)

Is this what you were talking about? Assuming the next step is to make the same "allow_blessed" option available from within Dancer::Session::Cookie, this does exactly what I need :)

Thanks for taking the time to go through this issue with me. I really appreciate it!
