### PR TITLE
Silent Crypt::CBC::encode() warning about deprecated opensslv1 PBKDF

### DIFF
--- a/lib/Session/Storage/Secure.pm
+++ b/lib/Session/Storage/Secure.pm
@@ -207,7 +207,7 @@ sub encode {
     my $salt = $self->_irand;
     my $key = hmac_sha256( $salt, $self->secret_key );
 
-    my $cbc = Crypt::CBC->new( -key => $key, -cipher => 'Rijndael' );
+    my $cbc = Crypt::CBC->new( -key => $key, -cipher => 'Rijndael', -pbkdf => 'opensslv1', -nodeprecate => 1 );
     my ( $ciphertext, $mac );
     eval {
         $ciphertext = $self->transport_encoder->( $cbc->encrypt( $self->_freeze($data) ) );


### PR DESCRIPTION
$ perl -MSession::Storage::Secure -e 'Session::Storage::Secure->new(secret_key=>1)->encode()'
WARNING: The key derivation method "opensslv1" is deprecated. Using -pbkdf=>'pbkdf2' would be better.
Pass -nodeprecate=>1 to inhibit this message.
 at /usr/share/perl5/vendor_perl/Session/Storage/Secure.pm line 213.

New CBC-Encrypt-3.01 defaults to -pbkdf => 'opensslv1' to preserve
compatibility and warns about that at the same time.

This silents the warning until a plan for a migration to the
stronger PBKDF is implemented in Session::Storage::Secure.

<https://github.com/dagolden/Session-Storage-Secure/issues/8>